### PR TITLE
Fixed for VRChat 1205

### DIFF
--- a/ParamLib.cs
+++ b/ParamLib.cs
@@ -1,5 +1,9 @@
 using System.Linq;
+using System.Reflection;
+using Il2CppSystem.Collections.Generic;
 using UnhollowerRuntimeLib.XrefScans;
+using UnityEngine;
+using VRC.Playables;
 using VRC.SDK3.Avatars.ScriptableObjects;
 using MethodInfo = System.Reflection.MethodInfo;
 
@@ -14,54 +18,15 @@ namespace ParamLib
 
         private static AvatarAnimParamController LocalAnimParamController => VRCPlayer.field_Internal_Static_VRCPlayer_0
             ?.field_Private_AnimatorControllerManager_0?.field_Private_AvatarAnimParamController_0;
-        
-        public static string[] ExcludedParams = {
-            "IsLocal",
-            "Viseme",
-            "Voice",
-            "GestureLeft",
-            "GestureRight",
-            "GestureLeftWeight",
-            "GestureRightWeight",
-            "AngularY",
-            "VelocityX",
-            "VelocityY",
-            "VelocityZ",
-            "Upright",
-            "Grounded",
-            "Seated",
-            "AFK",
-            "Expression1",
-            "Expression2",
-            "Expression3",
-            "Expression4",
-            "Expression5",
-            "Expression6",
-            "Expression7",
-            "Expression8",
-            "Expression9",
-            "Expression10",
-            "Expression11",
-            "Expression12",
-            "Expression13",
-            "Expression14",
-            "Expression15",
-            "Expression16",
-            "TrackingType",
-            "VRMode",
-            "MuteSelf",
-            "InStation"
-        };
-        
+
         private static readonly MethodInfo PrioritizeMethod = typeof(AvatarPlayableController).GetMethods().Where(info =>
                 info.Name.Contains("Method") && !info.Name.Contains("PDM") && info.Name.Contains("Public")
                 && info.GetParameters().Length == 1 && info.Name.Contains("Int32") &&
                 info.ReturnType == typeof(void))
             .First(method => XrefScanner.XrefScan(method).Any(xref => xref.Type == XrefType.Global && xref.ReadAsObject().ToString().Contains("Ran out of free puppet channels!")));
-
-        private static readonly MethodInfo SetMethod = typeof(AvatarPlayableController).GetMethods().First(m =>
-            m.Name.Contains("Boolean_Int32_Single") && !m.Name.Contains("PDM") &&
-            XrefScanner.UsedBy(m).Count(inst => inst.Type == XrefType.Method && inst.TryResolve()?.DeclaringType == typeof(AvatarPlayableController)) >= 4);
+        
+        //Why are we xreffing this? Both the _0 and the PDM work.
+        private static readonly MethodInfo SetMethod = typeof(AvatarPlayableController).GetMethods(BindingFlags.Public | BindingFlags.Instance).First(m => m.Name.Contains("Boolean_Int32_Single") && !m.Name.Contains("PDM"));
 
         public static void PrioritizeParameter(int paramIndex)
         {
@@ -70,41 +35,40 @@ namespace ParamLib
             PrioritizeMethod.Invoke(LocalPlayableController, new object[] { paramIndex });
         }
 
-        public static VRCExpressionParameters.Parameter[] GetLocalParams() =>
-            GetParams(VRCPlayer.field_Internal_Static_VRCPlayer_0);
-
         public static VRCExpressionParameters.Parameter[] GetParams(VRCPlayer player) => player?.prop_VRCAvatarManager_0
             ?.prop_VRCAvatarDescriptor_0?.expressionParameters
             ?.parameters;
 
+        public static Dictionary<int, AvatarParameter> GetPlayableParameters(VRCPlayer player) => player
+            ?.prop_VRCAvatarManager_0?.field_Private_AvatarPlayableController_0
+            ?.field_Private_Dictionary_2_Int32_AvatarParameter_0;
+
         public static bool DoesParamExist(string paramName, VRCExpressionParameters.ValueType paramType,
-            VRCExpressionParameters.Parameter[] parameters = null)
+            VRCPlayer player = null)
         {
-            // If they're null, then try getting LocalParams
-            parameters = parameters ?? GetLocalParams();
-            
+            // Always get the parameters from the VRCPlayer
+            var parameters = GetParams(player ? player : VRCPlayer.field_Internal_Static_VRCPlayer_0);
+
             // Separate Length from nulll check, otherwise you'll get a null exception if parameters are null
             return parameters != null && parameters.Any(p => p.name == paramName && p.valueType == paramType);
         }
         
         public static (int?, VRCExpressionParameters.Parameter) FindParam(string paramName, VRCExpressionParameters.ValueType paramType,
-            VRCExpressionParameters.Parameter[] parameters = null)
+            VRCPlayer player = null)
         {
-            var indexOffset = 0;
-            
-            // If they're null, then try getting LocalParams
-            parameters = parameters ?? GetLocalParams();
-            
-            if (parameters == null) return (null, null);
-            
+            // Get the PlayableParameters from the VRCPlayer
+            var parameters = GetParams(player ? player : VRCPlayer.field_Internal_Static_VRCPlayer_0);
+            var playableParams = GetPlayableParameters(player ? player : VRCPlayer.field_Internal_Static_VRCPlayer_0);
 
-            for (var i = 0; i < parameters.Length; i++)
+            var key = Animator.StringToHash(paramName);
+            
+            if (playableParams == null || !playableParams.ContainsKey(key)) return (null, null);
+
+            foreach (var t in parameters)
             {
-                var param = parameters[i];
+                var param = t;
                 if (param.name == null) continue;
-                //Fix for VRChat being dumb when someone uses a default param in their avatar
-                if (ExcludedParams.Contains(param.name)) indexOffset--;
-                if (param.name == paramName && param.valueType == paramType) return (i + indexOffset, parameters[i]);
+                if (param.name == paramName && param.valueType == paramType) return (key, t);
             }
 
             return (null, null);


### PR DESCRIPTION
Reworked FindParam to use AvatarPlayableController parameter dictionary instead of using ExpressionParameters as SetMethod has moved to using the key of the parameter dictionary.