### PR TITLE
Update SetMethod for VRChat 1205

### DIFF
--- a/ParamLib.cs
+++ b/ParamLib.cs
@@ -59,9 +59,9 @@ namespace ParamLib
                 info.ReturnType == typeof(void))
             .First(method => XrefScanner.XrefScan(method).Any(xref => xref.Type == XrefType.Global && xref.ReadAsObject().ToString().Contains("Ran out of free puppet channels!")));
 
-        private static readonly MethodInfo SetMethod = typeof(AvatarPlayableController).GetMethods().First(m =>
-            m.Name.Contains("Boolean_Int32_Single") && !m.Name.Contains("PDM") &&
-            XrefScanner.UsedBy(m).Count(inst => inst.Type == XrefType.Method && inst.TryResolve()?.DeclaringType == typeof(AvatarPlayableController)) >= 4);
+        private static readonly MethodInfo SetMethod = typeof(AvatarPlayableController)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance).First(m =>
+                m.Name.Contains("Method_Private_Boolean_Int32_Single") && m.GetParameters().Length == 2);
 
         public static void PrioritizeParameter(int paramIndex)
         {

--- a/ParamLib.cs
+++ b/ParamLib.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Reflection;
 using UnhollowerRuntimeLib.XrefScans;
 using VRC.SDK3.Avatars.ScriptableObjects;
 using MethodInfo = System.Reflection.MethodInfo;


### PR DESCRIPTION
Fixed reflection on SetMethod to point at the private PDM for SetMethod, publics have changed and now require the AvatarParameter key instead.